### PR TITLE
Exporting angular.mock instead of module.exports of angular-mocks

### DIFF
--- a/mocks.js
+++ b/mocks.js
@@ -1,1 +1,2 @@
-module.exports = require("./lib/angular-mocks");
+require("./lib/angular-mocks");
+module.exports = angular.mock;


### PR DESCRIPTION
angular-mocks.js is not exporting anything and therefore it would be nice to shim the export by exporting angular.mock which is the mock namespace (containing angular.mock.inject, angular.mock.module etc).
